### PR TITLE
default seed changed to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,8 @@ panic = "abort"
 
 [profile.release]
 panic = "abort"
+
+[profile.maxperf]
+inherits = "release"
+lto = "fat"
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Introduction
 
-`avail-light-bootstrap` is called a Bootstrap node. Bootstrappers act as the initial point of contact for other Avail clients to find other peers in the network.
+`avail-light-bootstrap` is called a Bootstrap node. Bootstraps act as the initial point of contact for other Avail clients to find other peers in the network.
 
 These network entry points alow other newly joined nodes to discover new peers and to connect to them.
 
@@ -28,13 +28,14 @@ http_server_port = "7700"
 log_level = "info"
 # If set to true, logs are displayed in JSON format, which is used for structured logging. Otherwise, plain text format is used (default: false).
 log_format_json = false
-# Secret key used to generate keypair. Can be either set to `seed` or to `key`.
+# Secret key used to generate keypair. Can be either set to `seed` or to `key`. (default: seed="1")
 # If set to seed, keypair will be generated from that seed.
 # If set to key, a valid ed25519 private key must be provided, else the client will fail
 # If `secret_key` is not set, random seed will be used.
+# Default bootstrap peerID is 12D3KooWStAKPADXqJ7cngPYXd2mSANpdgh1xQ34aouufHA2xShz
 secret_key = { seed="1" }
 # P2P service port (default: 37000).
-port = 3700
+port = 37000
 # Sets application-specific version of the protocol family used by the peer. (default: "/avail_kad/id/1.0.0")
 identify_protocol = "/avail_kad/id/1.0.0"
 # Sets agent version that is sent to peers. (default: "avail-light-client/rust-client")

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,7 +27,7 @@ pub struct RuntimeConfig {
     /// If `secret_key` is not set, random seed will be used.
     /// Default bootstrap peerID is 12D3KooWStAKPADXqJ7cngPYXd2mSANpdgh1xQ34aouufHA2xShz
     pub secret_key: Option<SecretKey>,
-    /// Sets the listening P2P network service port. (default: 37000)
+    /// Sets the listening P2P network service port. (default: 39000)
     pub port: u16,
     /// Sets application-specific version of the protocol family used by the peer. (default: "/avail_kad/id/1.0.0")
     pub identify_protocol: String,
@@ -97,7 +97,7 @@ impl Default for RuntimeConfig {
             secret_key: Some(SecretKey::Seed {
                 seed: "1".to_string(),
             }),
-            port: 37000,
+            port: 39000,
             autonat_only_global_ips: false,
             identify_protocol: "/avail_kad/id/1.0.0".to_string(),
             identify_agent: "avail-light-client/rust-client".to_string(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,10 +21,11 @@ pub struct RuntimeConfig {
     pub log_level: String,
     /// Set to display structured logs in JSON format. Otherwise, plain text format is used. (default: false)
     pub log_format_json: bool,
-    /// Secret key for used to generate keypair. Can be either set to `seed` or to `key`.
+    /// Secret key used to generate keypair. Can be either set to `seed` or to `key`. (default: seed="1")
     /// If set to seed, keypair will be generated from that seed.
     /// If set to key, a valid ed25519 private key must be provided, else the client will fail
     /// If `secret_key` is not set, random seed will be used.
+    /// Default bootstrap peerID is 12D3KooWStAKPADXqJ7cngPYXd2mSANpdgh1xQ34aouufHA2xShz
     pub secret_key: Option<SecretKey>,
     /// Sets the listening P2P network service port. (default: 37000)
     pub port: u16,
@@ -93,7 +94,9 @@ impl Default for RuntimeConfig {
             http_server_port: 7700,
             log_level: "INFO".to_string(),
             log_format_json: false,
-            secret_key: None,
+            secret_key: Some(SecretKey::Seed {
+                seed: "1".to_string(),
+            }),
             port: 37000,
             autonat_only_global_ips: false,
             identify_protocol: "/avail_kad/id/1.0.0".to_string(),


### PR DESCRIPTION
- For ease of local setup, default `peerID` set to `12D3KooWStAKPADXqJ7cngPYXd2mSANpdgh1xQ34aouufHA2xShz` 
- `maxperf` build profile added to Cargo.toml