### PR TITLE
add support for GET method on health endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avail-light-bootstrap"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail-light-bootstrap"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 publish = false
 authors = ["Avail Team"]

--- a/README.md
+++ b/README.md
@@ -44,4 +44,10 @@ identify_agent = "avail-light-client/rust-client"
 kad_connection_idle_timeout = 30
 # Sets the timeout for a single Kademlia query. (default: 60s).
 kad_query_timeout = 60
+# OpenTelemetry Collector endpoint (default: `http://otelcollector.avail.tools:4317`)
+ot_collector_endpoint = "http://otelcollector.avail.tools:4317"
+# Defines a period of time in which periodic metric network dump events will be repeated. (default: 15s)
+metrics_network_dump_interval = 15
+# Defines a period of time in which periodic bootstraps will be repeated. (default: 300s)
+bootstrap_period = 300
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,7 @@ async fn run() -> Result<()> {
                     error!("Error recording network stats metric: {err}");
                 }
             };
+            _ = ot_metrics.record(MetricValue::HealthCheck()).await;
         }
     });
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,13 +4,19 @@ use tracing::info;
 use warp::Filter;
 
 pub async fn run(addr: Addr) {
-    let health_route = warp::head()
+    let health_route_get = warp::get()
         .and(warp::path("health"))
         .map(|| warp::reply::with_status("", warp::http::StatusCode::OK));
 
-    info!("HTTP server running on http://{addr}");
+    let health_route_head = warp::head()
+        .and(warp::path("health"))
+        .map(|| warp::reply::with_status("", warp::http::StatusCode::OK));
+
+    info!("HTTP server running on http://{addr}. Health endpoint available at '/health'.");
 
     let socket_addr: SocketAddr = addr.try_into().unwrap();
 
-    warp::serve(health_route).run(socket_addr).await;
+    warp::serve(health_route_get.or(health_route_head))
+        .run(socket_addr)
+        .await;
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,19 +4,14 @@ use tracing::info;
 use warp::Filter;
 
 pub async fn run(addr: Addr) {
-    let health_route_get = warp::get()
+    let health_route = warp::head()
+        .or(warp::get())
         .and(warp::path("health"))
-        .map(|| warp::reply::with_status("", warp::http::StatusCode::OK));
-
-    let health_route_head = warp::head()
-        .and(warp::path("health"))
-        .map(|| warp::reply::with_status("", warp::http::StatusCode::OK));
+        .map(|_| warp::reply::with_status("", warp::http::StatusCode::OK));
 
     info!("HTTP server running on http://{addr}. Health endpoint available at '/health'.");
 
     let socket_addr: SocketAddr = addr.try_into().unwrap();
 
-    warp::serve(health_route_get.or(health_route_head))
-        .run(socket_addr)
-        .await;
+    warp::serve(health_route).run(socket_addr).await;
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 
 pub enum MetricValue {
     KadRoutingPeerNum(usize),
+    HealthCheck(),
 }
 
 #[async_trait]

--- a/src/telemetry/otlp.rs
+++ b/src/telemetry/otlp.rs
@@ -14,9 +14,8 @@ pub struct Metrics {
 }
 
 impl Metrics {
-    async fn attributes(&self) -> [KeyValue; 6] {
+    async fn attributes(&self) -> [KeyValue; 5] {
         [
-            KeyValue::new("job", "avail_light_bootstrap"),
             KeyValue::new("version", clap::crate_version!()),
             KeyValue::new("role", self.role.clone()),
             KeyValue::new("peerID", self.peer_id.clone()),
@@ -52,6 +51,9 @@ impl super::Metrics for Metrics {
         match value {
             super::MetricValue::KadRoutingPeerNum(num) => {
                 self.record_u64("kad_routing_peer_num", num as u64).await?;
+            }
+            super::MetricValue::HealthCheck() => {
+                self.record_u64("up", 1).await?;
             }
         }
         Ok(())

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,7 +38,7 @@ pub struct RuntimeConfig {
     pub bootstrap_period: u64,
     /// OpenTelemetry Collector endpoint (default: http://otelcollector.avail.tools:4317)
     pub ot_collector_endpoint: String,
-    /// Defines a period of time in which periodic metric network dump events will be repeated. (default: 360s)
+    /// Defines a period of time in which periodic metric network dump events will be repeated. (default: 15s)
     pub metrics_network_dump_interval: u64,
     /// Secret key used to generate keypair. Can be either set to `seed` or to `key`. (default: seed="1")
     /// If set to seed, keypair will be generated from that seed.
@@ -105,7 +105,7 @@ impl Default for RuntimeConfig {
             kad_query_timeout: 60,
             bootstrap_period: 300,
             ot_collector_endpoint: "http://otelcollector.avail.tools:4317".to_string(),
-            metrics_network_dump_interval: 360,
+            metrics_network_dump_interval: 15,
         }
     }
 }


### PR DESCRIPTION
- Added support for GET method on `/health` endpoint
- Added `up` metric for push based health check
- Changed the `metrics_network_dump_interval` from 360s to 15s
- Bump version to `0.0.4`
- Removed the `job` metric attribute to prevent Prometheus exporter panicking 