### PR TITLE
restructured p2p event loop logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,6 +1795,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,8 +2561,23 @@ checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3232,12 +3256,16 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ multihash = { version = "0.14.0", default-features = false, features = ["blake3"
 serde = { version = "1.0.163", features = ["derive"] }
 tokio = { version = "1.28.1", features = ["sync", "macros", "rt-multi-thread"] }
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.17", features = ["json"] }
+tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
 
 # OpenTelemetry
 opentelemetry = "0.20.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,10 @@ use clap::Parser;
 use libp2p::{multiaddr::Protocol, Multiaddr};
 use std::{net::Ipv4Addr, time::Duration};
 use tokio::time::{interval_at, Instant};
-use tracing::{error, info, metadata::ParseLevelError, warn, Level};
+use tracing::{error, info, metadata::ParseLevelError, warn, Level, Subscriber};
 use tracing_subscriber::{
-    fmt::format::{self, DefaultFields, Format, Full, Json},
-    FmtSubscriber,
+    fmt::format::{self},
+    EnvFilter, FmtSubscriber,
 };
 use types::RuntimeConfig;
 
@@ -40,16 +40,16 @@ fn parse_log_lvl(log_lvl: &str, default: Level) -> (Level, Option<ParseLevelErro
         .unwrap_or_else(|err| (default, Some(err)))
 }
 
-fn json_subscriber(log_lvl: Level) -> FmtSubscriber<DefaultFields, Format<Json>> {
+fn json_subscriber(log_lvl: Level) -> impl Subscriber + Send + Sync {
     FmtSubscriber::builder()
-        .with_max_level(log_lvl)
+        .with_env_filter(EnvFilter::new(format!("avail_light={log_lvl}")))
         .event_format(format::json())
         .finish()
 }
 
-fn default_subscriber(log_lvl: Level) -> FmtSubscriber<DefaultFields, Format<Full>> {
+fn default_subscriber(log_lvl: Level) -> impl Subscriber + Send + Sync {
     FmtSubscriber::builder()
-        .with_max_level(log_lvl)
+        .with_env_filter(EnvFilter::new(format!("avail_light={log_lvl}")))
         .with_span_events(format::FmtSpan::CLOSE)
         .finish()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,14 +42,14 @@ fn parse_log_lvl(log_lvl: &str, default: Level) -> (Level, Option<ParseLevelErro
 
 fn json_subscriber(log_lvl: Level) -> impl Subscriber + Send + Sync {
     FmtSubscriber::builder()
-        .with_env_filter(EnvFilter::new(format!("avail_light={log_lvl}")))
+        .with_env_filter(EnvFilter::new(format!("avail_light_bootstrap={log_lvl}")))
         .event_format(format::json())
         .finish()
 }
 
 fn default_subscriber(log_lvl: Level) -> impl Subscriber + Send + Sync {
     FmtSubscriber::builder()
-        .with_env_filter(EnvFilter::new(format!("avail_light={log_lvl}")))
+        .with_env_filter(EnvFilter::new(format!("avail_light_bootstrap={log_lvl}")))
         .with_span_events(format::FmtSpan::CLOSE)
         .finish()
 }

--- a/src/network/event_loop.rs
+++ b/src/network/event_loop.rs
@@ -14,7 +14,7 @@ use tokio::{
     sync::{mpsc, oneshot},
     time::{interval_at, Instant, Interval},
 };
-use tracing::{debug, error, info, trace};
+use tracing::{debug, info, trace};
 
 enum QueryChannel {
     Bootstrap(oneshot::Sender<Result<()>>),
@@ -79,7 +79,7 @@ impl EventLoop {
             }
         }
     }
-
+    #[tracing::instrument(level = "trace", skip(self))]
     async fn handle_event(&mut self, event: SwarmEvent<BehaviourEvent, StreamError>) {
         match event {
             SwarmEvent::Behaviour(BehaviourEvent::Kademlia(kad_event)) => match kad_event {
@@ -90,7 +90,7 @@ impl EventLoop {
                     old_peer,
                     ..
                 } => {
-                    debug!("Routing updated. Peer: {peer:?}. Is new Peer: {is_new_peer:?}. Addresses: {addresses:#?}. Old Peer: {old_peer:#?}");
+                    trace!("Routing updated. Peer: {peer:?}. Is new Peer: {is_new_peer:?}. Addresses: {addresses:#?}. Old Peer: {old_peer:#?}");
                     if let Some(ch) = self.pending_kad_routing.remove(&peer) {
                         _ = ch.send(Ok(()));
                     }
@@ -148,24 +148,24 @@ impl EventLoop {
             SwarmEvent::Behaviour(BehaviourEvent::AutoNat(autonat_event)) => match autonat_event {
                 AutoNATEvent::InboundProbe(inbound_event) => match inbound_event {
                     InboundProbeEvent::Error { peer, error, .. } => {
-                        error!(
+                        debug!(
                             "AutoNAT Inbound Probe failed with Peer: {:?}. Error: {:?}.",
                             peer, error
                         );
                     }
                     _ => {
-                        debug!("AutoNAT Inbound Probe: {:#?}", inbound_event);
+                        trace!("AutoNAT Inbound Probe: {:#?}", inbound_event);
                     }
                 },
                 AutoNATEvent::OutboundProbe(outbound_event) => match outbound_event {
                     OutboundProbeEvent::Error { peer, error, .. } => {
-                        error!(
+                        debug!(
                             "AutoNAT Outbound Probe failed with Peer: {:#?}. Error: {:?}",
                             peer, error
                         );
                     }
                     _ => {
-                        debug!("AutoNAT Outbound Probe: {:#?}", outbound_event);
+                        trace!("AutoNAT Outbound Probe: {:#?}", outbound_event);
                     }
                 },
 


### PR DESCRIPTION
- Suppressed logs from crates other than avail_light to ERROR level only
- Added tracing instrumentation to the event handler function in p2p event loop
- Downgraded most of the p2p DEBUG level logs to TRACES
- Set AutoNat probe errors to trace level 