### PR TITLE
Expose autonat configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avail-light-bootstrap"
-version = "0.0.6"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail-light-bootstrap"
-version = "0.0.6"
+version = "0.0.9"
 edition = "2021"
 publish = false
 authors = ["Avail Team"]

--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -70,7 +70,10 @@ pub fn init(cfg: LibP2PConfig, id_keys: Keypair) -> Result<(Client, EventLoop)> 
 
             // create AutoNAT Server Config
             let autonat_cfg = autonat::Config {
-                only_global_ips: cfg.autonat_only_global_ips,
+                only_global_ips: cfg.autonat.only_global_ips,
+                throttle_clients_global_max: cfg.autonat.throttle_clients_global_max,
+                throttle_clients_peer_max: cfg.autonat.throttle_clients_peer_max,
+                throttle_clients_period: cfg.autonat.throttle_clients_period,
                 ..Default::default()
             };
 


### PR DESCRIPTION
- Exposed relevant `autonat` server configuration parameters
- Increased default `autonat_throttle_clients_global_max`  to 120, `autonat_throttle_clients_peer_max` to 4 and changed `autonat_only_global_ips` to true